### PR TITLE
Add build info display and report metadata

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,9 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        val githubRunNumber = System.getenv("GITHUB_RUN_NUMBER") ?: "0"
+        buildConfigField("String", "BUILD_NUMBER", "\"$githubRunNumber\"")
     }
 
     buildTypes {
@@ -39,6 +42,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
     packaging {
         resources.excludes.add("META-INF/DEPENDENCIES")

--- a/app/src/main/assets/settings.json
+++ b/app/src/main/assets/settings.json
@@ -3,5 +3,6 @@
   "default_camera": "standard",
   "aggregateCodeFilterTemplate": "^]C1",
   "aggregatedCodeFilterTemplate": "^\\u001d",
-  "coolingPeriodMs": 500
+  "coolingPeriodMs": 500,
+  "showBuildInfo": true
 }

--- a/app/src/main/java/com/example/scan/MainActivity.kt
+++ b/app/src/main/java/com/example/scan/MainActivity.kt
@@ -14,6 +14,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.os.Build
+import android.provider.Settings
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Size
@@ -109,6 +110,7 @@ class MainActivity : AppCompatActivity(), BarcodeScannerProcessor.OnBarcodeScann
             updateCameraFocusMode()
         }
 
+        updateBuildInfoDisplay()
         handleIntent(intent)
     }
 
@@ -237,6 +239,7 @@ class MainActivity : AppCompatActivity(), BarcodeScannerProcessor.OnBarcodeScann
         // If the file was processed, update the UI. Otherwise, show an error and do nothing to the UI.
         if (isFileProcessed) {
             updateUiForTaskMode()
+            updateBuildInfoDisplay()
         } else {
             Log.e(TAG, "Failed to parse JSON content as Task or Settings")
             val errorMessage = if (taskParseError != null) "Invalid file format: $taskParseError" else "Invalid file format"
@@ -291,11 +294,23 @@ class MainActivity : AppCompatActivity(), BarcodeScannerProcessor.OnBarcodeScann
                 viewBinding.gtinText.text = "GTIN: ${it.gtin ?: "N/A"}"
                 viewBinding.lotNoText.text = "Lot: ${it.lotNo ?: "N/A"}"
                 viewBinding.expDateText.text = "Exp: ${it.expDate ?: "N/A"}"
+                viewBinding.numPacksText.text = "numPacksInBox: ${it.numPacksInBox}"
             }
             updateAggregateCount()
             viewBinding.aggregateCountText.visibility = View.VISIBLE
         } else {
             viewBinding.aggregateCountText.visibility = View.GONE
+        }
+    }
+
+    private fun updateBuildInfoDisplay() {
+        if (settingsManager.isShowBuildInfoEnabled()) {
+            val buildNumber = BuildConfig.BUILD_NUMBER
+            val androidId = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID) ?: "unknown"
+            viewBinding.buildInfoText.text = "Build: $buildNumber | ID: $androidId"
+            viewBinding.buildInfoText.visibility = View.VISIBLE
+        } else {
+            viewBinding.buildInfoText.visibility = View.GONE
         }
     }
 
@@ -329,11 +344,18 @@ class MainActivity : AppCompatActivity(), BarcodeScannerProcessor.OnBarcodeScann
         val aggregateFilter = settingsManager.getAggregateCodeFilterTemplate()
         val aggregatedFilter = settingsManager.getAggregatedCodeFilterTemplate()
 
+        val androidId = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID) ?: ""
+        val model = Build.MODEL ?: ""
+        val buildNumber = BuildConfig.BUILD_NUMBER
+
         val report = ReportGenerator.generateAggregationReport(
             task,
             allPackages,
             aggregateFilter,
-            aggregatedFilter
+            aggregatedFilter,
+            operator = androidId,
+            model = model,
+            build = buildNumber
         )
 
         val jsonString = Json.encodeToString(report)

--- a/app/src/main/java/com/example/scan/SettingsManager.kt
+++ b/app/src/main/java/com/example/scan/SettingsManager.kt
@@ -42,6 +42,10 @@ class SettingsManager(private val context: Context) {
         return sharedPreferences.getBoolean(KEY_SAVE_IMAGES, loadSettingsFromAssets().saveImages)
     }
 
+    fun isShowBuildInfoEnabled(): Boolean {
+        return sharedPreferences.getBoolean(KEY_SHOW_BUILD_INFO, loadSettingsFromAssets().showBuildInfo)
+    }
+
     private fun saveSettings(settings: Settings) {
         sharedPreferences.edit()
             .putString(KEY_SERVICE_URL, settings.serviceUrl)
@@ -50,6 +54,7 @@ class SettingsManager(private val context: Context) {
             .putString(KEY_AGGREGATED_CODE_FILTER_TEMPLATE, settings.aggregatedCodeFilterTemplate)
             .putLong(KEY_COOLING_PERIOD_MS, settings.coolingPeriodMs)
             .putBoolean(KEY_SAVE_IMAGES, settings.saveImages)
+            .putBoolean(KEY_SHOW_BUILD_INFO, settings.showBuildInfo)
             .apply()
     }
 
@@ -103,6 +108,7 @@ class SettingsManager(private val context: Context) {
         private const val KEY_AGGREGATED_CODE_FILTER_TEMPLATE = "aggregated_code_filter_template"
         private const val KEY_COOLING_PERIOD_MS = "cooling_period_ms"
         private const val KEY_SAVE_IMAGES = "save_images"
+        private const val KEY_SHOW_BUILD_INFO = "show_build_info"
         private const val TAG = "SettingsManager"
     }
 }
@@ -114,5 +120,6 @@ private data class Settings(
     val aggregateCodeFilterTemplate: String = "^]C1",
     val aggregatedCodeFilterTemplate: String = "^\\u001d",
     val coolingPeriodMs: Long = 500L,
-    val saveImages: Boolean = true
+    val saveImages: Boolean = true,
+    val showBuildInfo: Boolean = true
 )

--- a/app/src/main/java/com/example/scan/model/AggregationReport.kt
+++ b/app/src/main/java/com/example/scan/model/AggregationReport.kt
@@ -7,6 +7,9 @@ data class AggregationReport(
     val id: String,
     val startTime: String,
     val endTime: String,
+    val operator: String = "",
+    val model: String = "",
+    val build: String = "",
     val readyBox: List<ReadyBox>
 )
 

--- a/app/src/main/java/com/example/scan/utility/ReportGenerator.kt
+++ b/app/src/main/java/com/example/scan/utility/ReportGenerator.kt
@@ -21,7 +21,10 @@ object ReportGenerator {
         task: Task,
         allPackages: List<AggregatePackage>,
         aggregateFilter: String,
-        aggregatedFilter: String
+        aggregatedFilter: String,
+        operator: String = "",
+        model: String = "",
+        build: String = ""
     ): AggregationReport {
         val readyBoxes = allPackages.mapIndexed { index, pkg ->
             val filteredSscc = CodeFilter.symbologiesSymbolsFilter(pkg.sscc, aggregateFilter)
@@ -40,6 +43,9 @@ object ReportGenerator {
             id = task.id,
             startTime = task.startTime,
             endTime = formatInstant(System.currentTimeMillis()),
+            operator = operator,
+            model = model,
+            build = build,
             readyBox = readyBoxes
         )
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -160,7 +160,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            app:layout_constraintGuide_percent="0.191" />
+            app:layout_constraintGuide_percent="0.4" />
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/h_guideline_2"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,6 +21,20 @@
         app:layout_constraintRight_toRightOf="@id/preview_view"
         app:layout_constraintTop_toTopOf="@id/preview_view" />
 
+    <TextView
+        android:id="@+id/build_info_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:textColor="#AAAAAA"
+        android:textSize="8sp"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Build: 123 | ID: abc"
+        tools:visibility="visible" />
+
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/af_guideline_h"
         android:layout_width="wrap_content"
@@ -116,6 +130,14 @@
                 android:textColor="@android:color/white"
                 android:textSize="14sp"
                 tools:text="Exp: 281223" />
+
+            <TextView
+                android:id="@+id/num_packs_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@android:color/white"
+                android:textSize="14sp"
+                tools:text="Packs in box: 10" />
         </LinearLayout>
 
         <TextView

--- a/app/src/test/java/com/example/scan/utility/ReportGeneratorTest.kt
+++ b/app/src/test/java/com/example/scan/utility/ReportGeneratorTest.kt
@@ -71,10 +71,16 @@ class ReportGeneratorTest {
             task,
             listOf(pkg),
             "^]C1",
-            "^\u001d"
+            "^\u001d",
+            operator = "test-id",
+            model = "test-model",
+            build = "123"
         )
 
         assertEquals(1, report.readyBox.size)
+        assertEquals("test-id", report.operator)
+        assertEquals("test-model", report.model)
+        assertEquals("123", report.build)
         assertEquals("SSCC123", report.readyBox[0].boxNumber)
         assertEquals(1, report.readyBox[0].productNumbersFull.size)
         assertEquals("CODE1", report.readyBox[0].productNumbersFull[0])


### PR DESCRIPTION
This change introduces several requested features related to build information and report metadata:

1. **GitHub Actions Build Info**: 
   - Configured `app/build.gradle.kts` to capture the `GITHUB_RUN_NUMBER` environment variable as `BuildConfig.BUILD_NUMBER`.
   - Added a `TextView` to `activity_main.xml` to display this build number along with the device's Android ID in the top-left corner (8sp, gray font).
   - Added a `showBuildInfo` toggle in `SettingsManager` (defaulting to true) to control this display.

2. **Enhanced Aggregation Report**:
   - Updated the `AggregationReport` data model to include root-level fields: `operator` (Android ID), `model` (android.os.Build.MODEL), and `build` (build number).
   - Modified `ReportGenerator` to accept and include these fields when generating the final report.
   - Updated `MainActivity.closeTask()` to pass the correct device and build metadata to the generator.

3. **Task UI Improvement**:
   - Added the `numPacksInBox` field from the active task to the task info layout in `activity_main.xml`, ensuring it is visible during aggregation.

4. **Testing and Verification**:
   - Updated `ReportGeneratorTest` to verify that the new metadata fields are correctly included in the JSON report.
   - Verified that the build still succeeds and existing tests pass.

---
*PR created automatically by Jules for task [16931110341133745667](https://jules.google.com/task/16931110341133745667) started by @yankoval*